### PR TITLE
[codex] improve MiniCNN backend docs and CUDA legacy UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ for the backend-scoped completion report, and
 current follow-up TODO list.
 
 See [docs/backend_capabilities.md](docs/backend_capabilities.md) for the
-backend-by-backend support matrix.
+backend-by-backend support matrix. See
+[docs/cuda_batchnorm2d_evaluation.md](docs/cuda_batchnorm2d_evaluation.md) for
+the CUDA legacy BatchNorm2d integration assessment.
 
 Use [docs/benchmark_report_template.md](docs/benchmark_report_template.md) when
 recording backend performance results. `minicnn compare` reports elapsed time,

--- a/README.md
+++ b/README.md
@@ -162,6 +162,22 @@ See [docs/architecture.md](docs/architecture.md) for:
 - A full module map
 - Instructions for adding new layers and custom differentiable ops
 
+## Comparison and roadmap
+
+See [docs/comparison_report.md](docs/comparison_report.md) for the original
+comparison with `llm.c`, `tiny-cuda-nn`, and `neural-network-cuda`.
+
+See [docs/comparison_completion_report.md](docs/comparison_completion_report.md)
+for the backend-scoped completion report, and
+[docs/comparison_followup_todo.md](docs/comparison_followup_todo.md) for the
+current follow-up TODO list.
+
+See [docs/backend_capabilities.md](docs/backend_capabilities.md) for the
+backend-by-backend support matrix.
+
+Use [docs/benchmark_report_template.md](docs/benchmark_report_template.md) when
+recording backend performance results.
+
 ## Interactive tutorial
 
 `notebooks/01_autograd_from_scratch.ipynb` walks through the autograd engine from first principles:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ comparison with `llm.c`, `tiny-cuda-nn`, and `neural-network-cuda`.
 See [docs/comparison_completion_report.md](docs/comparison_completion_report.md)
 for the backend-scoped completion report, and
 [docs/comparison_followup_todo.md](docs/comparison_followup_todo.md) for the
-current follow-up TODO list.
+current follow-up TODO list. See
+[docs/optimization_progress.md](docs/optimization_progress.md) for the current
+optimization progress snapshot.
 
 See [docs/backend_capabilities.md](docs/backend_capabilities.md) for the
 backend-by-backend support matrix. See

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ See [docs/backend_capabilities.md](docs/backend_capabilities.md) for the
 backend-by-backend support matrix.
 
 Use [docs/benchmark_report_template.md](docs/benchmark_report_template.md) when
-recording backend performance results.
+recording backend performance results. `minicnn compare` reports elapsed time,
+epoch time, and samples/sec fields that map directly into the template.
 
 ## Interactive tutorial
 

--- a/configs/dual_backend_cnn.yaml
+++ b/configs/dual_backend_cnn.yaml
@@ -81,6 +81,7 @@ optimizer:
   lr_fc: 0.005
   momentum: 0.9
   weight_decay: 0.0005
+  grad_clip_global: 0.0  # cuda_legacy only; 0 disables global norm clipping
 
 scheduler:
   enabled: true

--- a/docs/04_python_ctypes_mnist.md
+++ b/docs/04_python_ctypes_mnist.md
@@ -78,7 +78,7 @@ FC(8*13*13 -> 10)
 Softmax cross entropy
 ```
 
-完整可執行版本已放在 [train_mnist_so.py](train_mnist_so.py)。該檔案不用 `torchvision`，只用 NumPy 與 Python 標準函式庫解析 MNIST IDX gzip 檔。
+完整可執行版本已放在 [`examples/mnist_ctypes/train_mnist_so.py`](../examples/mnist_ctypes/train_mnist_so.py)。該檔案不用 `torchvision`，只用 NumPy 與 Python 標準函式庫解析 MNIST IDX gzip 檔。
 
 ## 訓練流程骨架
 
@@ -162,13 +162,13 @@ lib.conv_update_fused(
 ## 完整範例檔
 
 ```text
-docs/train_mnist_so.py
+examples/mnist_ctypes/train_mnist_so.py
 ```
 
 較完整、較接近 framework 結構的重構版：
 
 ```text
-docs/train_mnist_so_full_cnn_frame.py
+examples/mnist_ctypes/train_mnist_so_full_cnn_frame.py
 ```
 
 重構版把重複的 Python orchestration 收斂到 `ConvBlock`、`DenseLayer`、dataclass cache、shape helper 與獨立 `SgdOptimizer`，保留同一組 `.so` C API。
@@ -178,7 +178,7 @@ docs/train_mnist_so_full_cnn_frame.py
 ```bash
 cd minicnn
 make -C cpp
-python3 -u docs/train_mnist_so.py --download
+python3 -u examples/mnist_ctypes/train_mnist_so.py --download
 ```
 
 第一次執行若本機沒有 MNIST，使用 `--download` 下載 gzip IDX 檔到 `data/mnist/`。如果機器不能連網，請先把四個 MNIST `.gz` 檔放到該目錄。
@@ -186,7 +186,7 @@ python3 -u docs/train_mnist_so.py --download
 ## 快速驗證
 
 ```bash
-cuda-memcheck python3 -u docs/train_mnist_so.py
+cuda-memcheck python3 -u examples/mnist_ctypes/train_mnist_so.py
 ```
 
 如果只想驗證 `.so` 函式本身，使用既有 sanity test：

--- a/docs/05_cpp_linking.md
+++ b/docs/05_cpp_linking.md
@@ -123,8 +123,8 @@ g++ examples/mnist_infer_demo.cpp \
 
 Python 端的 CIFAR-10 CUDA orchestration 已拆到
 `src/minicnn/training/cuda_batch.py`。若要對照 C++ 訓練流程，可從
-`train_cuda_batch()`、`forward_convs()`、`backward_convs_update()` 看每個 C
-API 的呼叫順序。
+`train_cuda_batch()`、`forward_convs()`、`backward_convs()`、`update_convs()`
+看每個 C API 的呼叫順序。
 
 Momentum update 的 C ABI prototype：
 

--- a/docs/08_autograd.md
+++ b/docs/08_autograd.md
@@ -11,7 +11,7 @@ It supports:
 - broadcasting-aware gradients
 - matrix multiply with `@`
 - `sum`, `mean`, and `reshape`
-- `relu`, `log_softmax`, and `cross_entropy`
+- `relu`, `log_softmax`, `cross_entropy`, `mse_loss`, and `bce_with_logits_loss`
 - trainable `Parameter`
 - `no_grad()` and `Tensor.detach()`
 - lightweight `SGD` and `Adam` optimizers with optional `grad_clip` and `weight_decay`
@@ -37,6 +37,23 @@ loss = cross_entropy(logits, target)
 loss.backward()
 
 SGD([w], lr=0.1).step()
+```
+
+`train-autograd` supports these loss config values:
+
+```yaml
+loss:
+  type: CrossEntropyLoss      # class-index targets
+```
+
+```yaml
+loss:
+  type: MSELoss               # labels are converted to dense targets
+```
+
+```yaml
+loss:
+  type: BCEWithLogitsLoss     # labels are converted to dense binary targets
 ```
 
 ## Tiny training run (random data)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -77,6 +77,10 @@ minicnn validate-config --config configs/dual_backend_cnn.yaml
 minicnn compile --config configs/autograd_tiny.yaml
 ```
 
+`compare` 會輸出每個 backend 的 `elapsed_s`、`avg_epoch_time_s`、
+`last_epoch_time_s`、`samples_per_sec`、train/val sample 數與 batch size，
+可直接填入 `docs/benchmark_report_template.md`。
+
 訓練產生的最佳模型檔固定寫入：
 
 ```text

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -105,7 +105,8 @@ Debug 時可直接用 config override 控制訓練參數：
 minicnn train-dual --config configs/dual_backend_cnn.yaml \
   engine.backend=cuda_legacy runtime.cuda_variant=cublas \
   train.epochs=1 train.batch_size=32 \
-  dataset.num_samples=128 dataset.val_samples=32
+  dataset.num_samples=128 dataset.val_samples=32 \
+  optimizer.grad_clip_global=2.0
 ```
 
 legacy trainer 也支援常用環境變數覆蓋：

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,7 +42,7 @@ CIFAR-10 legacy trainer 已拆成明確模組。`src/minicnn/training/train_cuda
 `docs/dual_backend_guide.md` 的 `When Architecture Changes Require Code Changes`
 決策表。
 
-MNIST 教學的最小版本是 `docs/train_mnist_so.py`；較乾淨的重構版本是 `docs/train_mnist_so_full_cnn_frame.py`，它把 CUDA orchestration 拆成 `ConvBlock`、`DenseLayer`、dataclass cache、shape helper 與獨立 `SgdOptimizer`。
+MNIST 教學的最小版本是 `examples/mnist_ctypes/train_mnist_so.py`；較乾淨的重構版本是 `examples/mnist_ctypes/train_mnist_so_full_cnn_frame.py`，它把 CUDA orchestration 拆成 `ConvBlock`、`DenseLayer`、dataclass cache、shape helper 與獨立 `SgdOptimizer`。
 
 若要同時編譯兩種 native backend：
 

--- a/docs/backend_capabilities.md
+++ b/docs/backend_capabilities.md
@@ -1,0 +1,77 @@
+# Backend Capabilities
+
+MiniCNN has three execution paths. Feature support should be read by backend,
+not as one global project-level checklist.
+
+## Summary Matrix
+
+| Capability | Torch/flex | CPU/NumPy autograd | CUDA legacy |
+|---|---:|---:|---:|
+| YAML model config | Yes | Yes | Yes, fixed CNN pattern only |
+| Custom Python components | Yes | Registry-based local components | No |
+| CIFAR-10 | Yes | Yes, slow for large runs | Yes |
+| MNIST | Yes | Yes, slow for large runs | No |
+| Random toy data | Yes | Yes | No |
+| Conv2d | Yes | Yes | Yes |
+| Linear | Yes | Yes | Yes |
+| MaxPool2d | Yes | Yes | Yes |
+| BatchNorm2d | Yes | Yes | No |
+| LayerNorm | Via PyTorch custom config | No built-in layer | Native kernel exists and is covered by NumPy/PyTorch parity tests, but is not wired into training |
+| ResidualBlock | Yes | Same-channel block | No |
+| ReLU / LeakyReLU | Yes | ReLU built in | Yes |
+| Sigmoid / Tanh | Yes | Yes | No |
+| Dropout | Yes | Yes | No |
+| CrossEntropyLoss | Yes | Yes | Yes |
+| MSELoss | Yes | Yes | No |
+| BCEWithLogitsLoss | Yes | Yes | No |
+| SGD | Yes | Yes | Yes |
+| Momentum SGD | Yes | Yes | Yes |
+| Adam | Yes | Yes | No |
+| AdamW | Yes | No | No |
+| AMP / mixed precision | Yes on CUDA | No | No |
+| Gradient accumulation | Yes | No | No |
+| Per-parameter norm clipping | Via PyTorch config or optimizer code | Yes | No |
+| Elementwise gradient clipping | Via custom code | No | Yes |
+| Native CUDA kernels | PyTorch-managed | No | Yes |
+| cuBLAS path | PyTorch-managed | No | Yes |
+
+## Torch/flex Backend
+
+Use this path for the broadest component coverage and fastest iteration. It is
+the right default for new model ideas, custom components, AMP experiments, and
+training workflows that do not need handwritten CUDA internals.
+
+## CPU/NumPy Autograd Backend
+
+Use this path for framework learning, small deterministic examples, and tests
+that should not depend on PyTorch. It is intentionally compact and CPU-only.
+Large Conv2d workloads are slow because the implementation favors clarity over
+throughput.
+
+## CUDA Legacy Backend
+
+Use this path to exercise the handwritten CUDA CNN. It is intentionally narrow:
+CIFAR-10, a fixed Conv/ReLU/Pool/Linear pattern, CrossEntropyLoss, and SGD-style
+updates. The current roadmap is to make this backend more credible before
+chasing production-scale features:
+
+- CUDA Adam or AdamW
+- CUDA BatchNorm2d
+- LayerNorm training integration or explicit experimental status
+- PyTorch parity tests
+- benchmark reports
+
+### LayerNorm Status
+
+`cpp/src/layer_norm.cu` contains native LayerNorm forward/backward kernels. The
+math is covered by `tests/test_layer_norm.py`, which compares the kernel logic
+against PyTorch through a NumPy mirror. The kernels are not part of the
+`cuda_legacy` training graph yet, so users should treat native LayerNorm as a
+tested kernel asset rather than a supported training-layer option.
+
+## Reading Config Errors
+
+If a config works with `engine.backend=torch` but fails with
+`engine.backend=cuda_legacy`, first check whether the layer, loss, optimizer, or
+dataset is listed as supported by CUDA legacy in the table above. This is often
+an expected backend limitation, not a parser bug.

--- a/docs/backend_capabilities.md
+++ b/docs/backend_capabilities.md
@@ -15,7 +15,7 @@ not as one global project-level checklist.
 | Conv2d | Yes | Yes | Yes |
 | Linear | Yes | Yes | Yes |
 | MaxPool2d | Yes | Yes | Yes |
-| BatchNorm2d | Yes | Yes | No |
+| BatchNorm2d | Yes | Yes | No; see `docs/cuda_batchnorm2d_evaluation.md` |
 | LayerNorm | Via PyTorch custom config | No built-in layer | Native kernel exists and is covered by NumPy/PyTorch parity tests, but is not wired into training |
 | ResidualBlock | Yes | Same-channel block | No |
 | ReLU / LeakyReLU | Yes | ReLU built in | Yes |
@@ -31,6 +31,7 @@ not as one global project-level checklist.
 | AMP / mixed precision | Yes on CUDA | No | No |
 | Gradient accumulation | Yes | No | No |
 | Per-parameter norm clipping | Via PyTorch config or optimizer code | Yes | No |
+| Global gradient norm clipping | Via PyTorch utilities if configured | No | Yes |
 | Elementwise gradient clipping | Via custom code | No | Yes |
 | Native CUDA kernels | PyTorch-managed | No | Yes |
 | cuBLAS path | PyTorch-managed | No | Yes |
@@ -56,7 +57,8 @@ updates. The current roadmap is to make this backend more credible before
 chasing production-scale features:
 
 - CUDA Adam or AdamW
-- CUDA BatchNorm2d
+- CUDA BatchNorm2d, after the native kernel/state/workspace plan in
+  `docs/cuda_batchnorm2d_evaluation.md`
 - LayerNorm training integration or explicit experimental status
 - PyTorch parity tests
 - benchmark reports

--- a/docs/benchmark_report_template.md
+++ b/docs/benchmark_report_template.md
@@ -1,0 +1,68 @@
+# MiniCNN Benchmark Report Template
+
+Use this template when comparing backend performance. Keep benchmark reports
+small, repeatable, and tied to exact commands.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Date | YYYY-MM-DD |
+| Host | |
+| GPU | |
+| Driver | |
+| CUDA toolkit | |
+| Python | |
+| PyTorch | |
+| MiniCNN commit | |
+
+## Commands
+
+```bash
+minicnn build --legacy-make --variant both --check
+```
+
+```bash
+minicnn train-dual --config configs/dual_backend_cnn.yaml \
+  engine.backend=torch train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
+```
+
+```bash
+minicnn train-dual --config configs/dual_backend_cnn.yaml \
+  engine.backend=cuda_legacy runtime.cuda_variant=cublas \
+  train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
+```
+
+```bash
+minicnn train-dual --config configs/dual_backend_cnn.yaml \
+  engine.backend=cuda_legacy runtime.cuda_variant=handmade \
+  train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
+```
+
+## Results
+
+| Backend | Variant | Train samples | Val samples | Batch size | Epoch time | Samples/sec | Peak GPU memory | Train acc | Val acc | Notes |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| torch | PyTorch CUDA | | | | | | | | | |
+| cuda_legacy | cublas | | | | | | | | | |
+| cuda_legacy | handmade | | | | | | | | | |
+
+## Correctness Checks
+
+- [ ] `python -m compileall -q src`
+- [ ] `pytest -q`
+- [ ] `minicnn build --legacy-make --variant both --check`
+- [ ] Relevant parity tests passed
+- [ ] Backend smoke matrix passed, if used
+
+## Interpretation
+
+Summarize what changed and whether the result is expected. Do not compare runs
+that used different sample counts, batch sizes, initial seeds, augmentation, or
+native library variants without calling that out explicitly.
+
+## Follow-up
+
+- [ ] Unexpected slowdown investigated
+- [ ] Any accuracy regression explained
+- [ ] CUDA memory growth checked for leaks

--- a/docs/benchmark_report_template.md
+++ b/docs/benchmark_report_template.md
@@ -23,21 +23,16 @@ minicnn build --legacy-make --variant both --check
 ```
 
 ```bash
-minicnn train-dual --config configs/dual_backend_cnn.yaml \
-  engine.backend=torch train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
+minicnn compare --config configs/dual_backend_cnn.yaml \
+  --backends torch cuda_legacy \
+  train.epochs=1 train.batch_size=64 \
+  dataset.num_samples=1024 dataset.val_samples=256 \
+  project.artifacts_root=/tmp/minicnn_bench
 ```
 
-```bash
-minicnn train-dual --config configs/dual_backend_cnn.yaml \
-  engine.backend=cuda_legacy runtime.cuda_variant=cublas \
-  train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
-```
-
-```bash
-minicnn train-dual --config configs/dual_backend_cnn.yaml \
-  engine.backend=cuda_legacy runtime.cuda_variant=handmade \
-  train.epochs=1 dataset.num_samples=1024 dataset.val_samples=256
-```
+The `compare` output includes `avg_epoch_time_s`, `last_epoch_time_s`, and
+`samples_per_sec`. For CUDA native variant comparisons, run the command once
+with `runtime.cuda_variant=cublas` and once with `runtime.cuda_variant=handmade`.
 
 ## Results
 

--- a/docs/comparison_completion_report.md
+++ b/docs/comparison_completion_report.md
@@ -1,0 +1,163 @@
+# MiniCNN Comparison Completion Report
+
+This report reviews MiniCNN against:
+
+- [karpathy/llm.c](https://github.com/karpathy/llm.c)
+- [NVlabs/tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn)
+- [BobMcDear/neural-network-cuda](https://github.com/BobMcDear/neural-network-cuda)
+
+It builds on `docs/comparison_report.md`, but corrects the main ambiguity in that
+report: MiniCNN has three different capability layers, and missing features must
+be scoped to the correct layer.
+
+## Executive Summary
+
+MiniCNN is not mainly missing framework structure. It is missing broader and more
+general handwritten CUDA backend coverage.
+
+MiniCNN already has a stronger user-facing framework than
+`neural-network-cuda`: YAML configs, CLI training, tests, docs, a Torch backend,
+a CPU/NumPy autograd stack, and a CUDA legacy backend. Compared with `llm.c` and
+`tiny-cuda-nn`, the gap is not that MiniCNN lacks a project shape. The gap is
+that those projects specialize in production-scale or performance-first CUDA
+systems, while MiniCNN is still strongest as an educational dual-backend CNN
+framework.
+
+The most valuable next work is to make `cuda_legacy` a more credible backend:
+CUDA Adam/AdamW, CUDA BatchNorm2d, LayerNorm integration, parity tests, global
+gradient norm clipping, and real throughput reports.
+
+## Capability Layers
+
+| Layer | Current status |
+|---|---|
+| Torch/flex backend | Supports configurable PyTorch modules, BatchNorm2d, Dropout, ResidualBlock, GlobalAvgPool2d, MSELoss, BCEWithLogitsLoss, CrossEntropyLoss, SGD, Adam, AdamW, AMP, schedulers, custom components. |
+| CPU/NumPy autograd | Supports Tensor backward, Function API, Conv2d, MaxPool2d, BatchNorm2d, ResidualBlock, Sigmoid, Tanh, Dropout, CrossEntropy, SGD, Adam, weight decay, and gradient clipping. |
+| CUDA legacy backend | Supports a fixed CIFAR-10 CNN pattern with Conv2d, LeakyReLU/ReLU, MaxPool2d, Flatten, Linear, CrossEntropy, SGD/momentum, weight decay, elementwise clipping, cuBLAS and handmade variants, plus a LayerNorm kernel that is not wired into the main training path. |
+
+This split matters. Some items listed as "missing" in the original comparison
+report are not missing from MiniCNN overall; they are missing specifically from
+`cuda_legacy`.
+
+## Comparison With neural-network-cuda
+
+`neural-network-cuda` is a from-scratch CUDA/C++ neural network project intended
+as a CUDA introduction. Its README describes CPU and GPU versions with similar
+syntax and core pieces such as Linear, ReLU, MSE, Sequential, and simple
+gradient-descent training.
+
+MiniCNN already exceeds it in most practical dimensions:
+
+| Area | neural-network-cuda | MiniCNN |
+|---|---|---|
+| CNN support | Not the main focus | Conv/Pool CUDA path and autograd Conv/Pool |
+| User interface | C++/CUDA examples | CLI, YAML configs, templates, docs |
+| Backend choice | CPU and GPU C++ variants | Torch, CPU/NumPy autograd, CUDA legacy |
+| Testing | Basic project tests | Broad Python and CUDA smoke tests |
+| Extensibility | Manual C++ composition | Config-driven model building and custom components |
+
+What MiniCNN can still borrow from it is simplicity: a short, beginner-friendly
+"CUDA from scratch" path that avoids making new users understand the whole
+framework at once.
+
+## Comparison With llm.c
+
+`llm.c` is a pure C/CUDA LLM training project focused on GPT-2/GPT-3 style
+pretraining, with PyTorch reference code, CPU and CUDA implementations,
+mixed-precision testing, cuDNN Flash Attention, and multi-GPU/multi-node paths
+through MPI/NCCL.
+
+MiniCNN should not chase the full `llm.c` scope. The useful lessons are:
+
+| Gap | Recommendation | Difficulty | Reason |
+|---|---|---:|---|
+| CUDA Adam/AdamW | Add | Medium | Directly improves `cuda_legacy` training usability. |
+| LayerNorm training integration | Add or clearly mark experimental | Low-medium | Kernel exists; user path is missing. |
+| PyTorch parity tests | Add | Medium | Critical for handwritten CUDA correctness. |
+| Global gradient norm clipping | Add | Medium | More standard than elementwise clipping. |
+| FP16/BF16 CUDA path | Defer | High | Requires dtype changes, loss scaling, and numerical validation. |
+| Embedding/Transformer/Attention | Do not prioritize | High to very high | Pulls MiniCNN away from its CNN/framework teaching focus. |
+| Multi-GPU or multi-node training | Do not prioritize now | Very high | Infrastructure-heavy and low value before single-GPU CUDA is broader. |
+
+The best `llm.c` idea for MiniCNN is not GPT training. It is rigorous reference
+testing: save debug states, compare forward/backward/update results against
+PyTorch, and make CUDA regressions easy to catch.
+
+## Comparison With tiny-cuda-nn
+
+`tiny-cuda-nn` is a performance-first C++/CUDA framework. Its main strengths are
+fully fused MLPs, multiresolution hash/grid encodings, a PyTorch extension,
+JIT fusion, FP16, CUTLASS MLPs, and many losses/optimizers. It is a neural
+graphics and small-MLP acceleration library, not a CNN teaching framework.
+
+MiniCNN should borrow its component clarity and benchmarking discipline, not its
+entire technical scope.
+
+| Gap | Recommendation | Difficulty | Reason |
+|---|---|---:|---|
+| CUDA Adam | Add | Medium | Common optimizer expected by users. |
+| More CUDA losses | Add selectively | Low-medium | MSE/BCE/L1 would broaden examples. |
+| Benchmark reports | Add | Low-medium | Helps users understand backend tradeoffs. |
+| FP16 CUDA path | Defer | High | Valuable but cross-cutting. |
+| Fully fused MLP | Do not prioritize | Very high | Not aligned with MiniCNN's CNN/backend teaching focus. |
+| HashGrid/positional encoding | Do not prioritize | High | Mostly relevant to NeRF/neural graphics. |
+| JIT fusion | Do not prioritize | Very high | Major runtime compiler project. |
+| CUTLASS/Tensor Core work | Do not prioritize now | Very high | cuBLAS already provides a strong baseline. |
+
+## Corrections To The Existing Comparison Report
+
+1. "MSE/BCE loss missing" should be scoped. Torch/flex already has MSELoss and
+   BCEWithLogitsLoss. CPU/NumPy autograd and CUDA legacy are the missing layers.
+2. "BatchNorm missing" should be scoped. Torch/flex and CPU/NumPy autograd
+   already have BatchNorm2d. CUDA legacy is missing the native BatchNorm path.
+3. "Sigmoid/Tanh from neural-network-cuda" is not a precise comparison point.
+   That repo's README clearly lists Linear, ReLU, MSE, Sequential, and training
+   utilities as core pieces.
+4. The LayerNorm note is valid: MiniCNN has a native LayerNorm kernel, but it is
+   not part of the main CUDA legacy training path.
+5. Framework completeness should be phrased carefully. MiniCNN is more complete
+   as a configurable educational framework, but `llm.c` is far more complete as
+   an LLM training system and `tiny-cuda-nn` is far more complete as a
+   performance-first CUDA MLP/encoding system.
+
+## Recommended Work Plan
+
+| Priority | Work item | User value | Difficulty |
+|---:|---|---|---:|
+| 1 | Add CUDA Adam/AdamW or at least CUDA Adam | Users can train CUDA backend with a modern optimizer. | Medium |
+| 2 | Add CUDA BatchNorm2d forward/backward and YAML/runtime support | Makes VGG/ResNet-like CUDA configs realistic. | Medium |
+| 3 | Wire LayerNorm into a documented CUDA path or mark it experimental | Removes an orphan native capability. | Low-medium |
+| 4 | Add MSE/BCE to autograd and selected CUDA loss support | Enables regression and binary classification examples. | Low-medium |
+| 5 | Add PyTorch parity tests for CUDA kernels | Raises confidence in handwritten CUDA. | Medium |
+| 6 | Add benchmark reports for throughput, epoch time, and GPU memory | Gives users clear backend tradeoffs. | Low-medium |
+| 7 | Add global gradient norm clipping | More standard optimizer behavior. | Medium |
+| 8 | Add CUDA skip/residual add path | Unlocks more natural ResNet-like CUDA training. | Medium |
+| 9 | Add CUDA Sigmoid/Tanh/Dropout | Improves completeness, but lower priority for CNN path. | Low-medium |
+| 10 | Explore CUDA FP16 only after the above is stable | Performance upside, but high implementation risk. | High |
+
+## Not Recommended For The Current Roadmap
+
+- Multi-GPU, NCCL, MPI, or multi-node training.
+- Flash Attention, Transformer blocks, or GPT-style training.
+- tiny-cuda-nn style fully fused MLP kernels.
+- HashGrid or neural graphics encodings.
+- JIT fusion or runtime CUDA code generation.
+- CUTLASS/Tensor Core rewrites before stronger baseline benchmarks exist.
+
+These are technically interesting, but they would change MiniCNN's scope and
+delay higher-value improvements to the existing user path.
+
+## Final Positioning
+
+MiniCNN is best positioned as a dual-backend educational CNN framework:
+
+- Torch/flex for fast experimentation and broad PyTorch component coverage.
+- CPU/NumPy autograd for framework learning and tests without PyTorch.
+- CUDA legacy for owning and understanding handwritten CUDA kernels.
+
+The next milestone should be "credible single-GPU CUDA backend for common CNN
+training", not "match llm.c" or "match tiny-cuda-nn". After CUDA Adam,
+BatchNorm2d, LayerNorm integration, parity tests, and benchmarks land, MiniCNN's
+value proposition becomes much clearer: one config can run through PyTorch for
+experimentation and through handwritten CUDA for low-level learning and backend
+control.

--- a/docs/comparison_followup_todo.md
+++ b/docs/comparison_followup_todo.md
@@ -1,0 +1,39 @@
+# MiniCNN Comparison Follow-up TODO
+
+This file tracks follow-up work from `docs/comparison_completion_report.md`.
+It keeps the roadmap scoped by backend so feature gaps are not confused across
+Torch/flex, CPU/NumPy autograd, and CUDA legacy.
+
+## In Progress
+
+- [x] Link comparison follow-up docs from the main README so the report is not
+  an orphan document.
+- [x] Add CPU/NumPy autograd `mse_loss` and `bce_with_logits_loss`.
+- [x] Let `minicnn train-autograd` select `CrossEntropyLoss`, `MSELoss`, or
+  `BCEWithLogitsLoss` from config.
+- [x] Add focused tests for the new autograd losses.
+- [x] Add a backend capability matrix covering Torch/flex, CPU/NumPy autograd,
+  and CUDA legacy.
+
+## Next
+
+- [x] Document the native LayerNorm kernel as tested but not wired into the
+  CUDA legacy training path.
+- [x] Add PyTorch parity tests for small autograd and CUDA kernel cases.
+- [x] Add a benchmark report template for samples/sec, epoch time, and GPU
+  memory.
+
+## Later CUDA Work
+
+- [ ] Add CUDA Adam or AdamW optimizer state and update kernels.
+- [ ] Add CUDA BatchNorm2d forward/backward and config/runtime support.
+- [ ] Add global gradient norm clipping for CUDA legacy.
+- [ ] Add CUDA residual/skip add support after the legacy model compiler can
+  represent it cleanly.
+
+## Deferred
+
+- [ ] CUDA FP16/AMP support.
+- [ ] Multi-GPU, NCCL, MPI, or multi-node training.
+- [ ] Transformer, Flash Attention, or GPT-style training.
+- [ ] tiny-cuda-nn style fully fused MLPs, HashGrid encodings, or JIT fusion.

--- a/docs/comparison_followup_todo.md
+++ b/docs/comparison_followup_todo.md
@@ -4,6 +4,8 @@ This file tracks follow-up work from `docs/comparison_completion_report.md`.
 It keeps the roadmap scoped by backend so feature gaps are not confused across
 Torch/flex, CPU/NumPy autograd, and CUDA legacy.
 
+For the latest uploaded progress snapshot, see `docs/optimization_progress.md`.
+
 ## In Progress
 
 - [x] Link comparison follow-up docs from the main README so the report is not

--- a/docs/comparison_followup_todo.md
+++ b/docs/comparison_followup_todo.md
@@ -28,12 +28,14 @@ Torch/flex, CPU/NumPy autograd, and CUDA legacy.
   and config overrides can be used in the same command.
 - [x] Clean up `Tensor.__pow__` zero-base negative-exponent warnings while
   preserving the existing zero-gradient behavior.
+- [x] Add global gradient norm clipping for CUDA legacy.
+- [x] Evaluate CUDA legacy BatchNorm2d forward/backward integration and record
+  the required kernel, state, workspace, checkpoint, and test work.
 
 ## Later CUDA Work
 
 - [ ] Add CUDA Adam or AdamW optimizer state and update kernels.
 - [ ] Add CUDA BatchNorm2d forward/backward and config/runtime support.
-- [ ] Add global gradient norm clipping for CUDA legacy.
 - [ ] Add CUDA residual/skip add support after the legacy model compiler can
   represent it cleanly.
 

--- a/docs/comparison_followup_todo.md
+++ b/docs/comparison_followup_todo.md
@@ -22,6 +22,12 @@ Torch/flex, CPU/NumPy autograd, and CUDA legacy.
 - [x] Add PyTorch parity tests for small autograd and CUDA kernel cases.
 - [x] Add a benchmark report template for samples/sec, epoch time, and GPU
   memory.
+- [x] Add benchmark fields to `minicnn compare` so users can fill the report
+  template without hand-computing epoch time or samples/sec.
+- [x] Fix `minicnn compare --backends ... key=value` parsing so backend lists
+  and config overrides can be used in the same command.
+- [x] Clean up `Tensor.__pow__` zero-base negative-exponent warnings while
+  preserving the existing zero-gradient behavior.
 
 ## Later CUDA Work
 

--- a/docs/comparison_report.md
+++ b/docs/comparison_report.md
@@ -1,5 +1,11 @@
 # MiniCNN vs llm.c / tiny-cuda-nn / neural-network-cuda 完成度報告
 
+> Update: this report is the original comparison draft. For the corrected
+> backend-scoped version, see `docs/comparison_completion_report.md`. In
+> particular, MSE/BCE, BatchNorm2d, ResidualBlock, and Adam are already present
+> in some MiniCNN paths; the remaining gaps are mostly specific to
+> `cuda_legacy`.
+
 ## 先定位各自的賽道
 
 | 專案 | 定位 | 目標讀者 |

--- a/docs/cuda_batchnorm2d_evaluation.md
+++ b/docs/cuda_batchnorm2d_evaluation.md
@@ -1,0 +1,58 @@
+# CUDA Legacy BatchNorm2d Evaluation
+
+This note records the current state of BatchNorm2d for the handcrafted
+`cuda_legacy` backend.
+
+## Current Status
+
+BatchNorm2d is supported by the Torch/flex backend and by the CPU/NumPy autograd
+backend. It is not supported by CUDA legacy training yet.
+
+The CUDA legacy backend validates a fixed CIFAR-10 training graph:
+
+```text
+Conv2d -> ReLU/LeakyReLU -> Conv2d -> ReLU/LeakyReLU -> MaxPool2d
+-> Conv2d -> ReLU/LeakyReLU -> Conv2d -> ReLU/LeakyReLU -> MaxPool2d
+-> Flatten -> Linear
+```
+
+If `BatchNorm2d` appears in a `cuda_legacy` config, validation now reports that
+the layer is unsupported and tells users to use `engine.backend=torch` or remove
+BatchNorm2d for the handcrafted CUDA path.
+
+## What Is Missing
+
+CUDA legacy needs more than standalone forward/backward math before BatchNorm2d
+can be called supported:
+
+| Area | Missing Work |
+|---|---|
+| Native kernels | BatchNorm2d train forward, eval forward, backward input, backward gamma, backward beta |
+| Runtime state | Per-BN gamma, beta, running mean, running var, and velocity buffers |
+| Workspace | Saved batch mean, inverse std, normalized activation, and gradient buffers per BN layer |
+| Compiler/validator | A CUDA legacy layer pattern that accepts Conv-BN-Activation blocks |
+| Checkpoints | Save/load BN affine parameters and running stats |
+| Updates | SGD/momentum updates for BN gamma and beta, with no weight decay on beta |
+| Tests | NumPy/PyTorch parity for forward, backward, running stats, and one training step |
+
+## Recommended Integration Order
+
+1. Add a pure NumPy BatchNorm2d reference test for train/eval forward and
+   backward against PyTorch.
+2. Add native CUDA kernels behind explicit C ABI symbols without wiring them
+   into training.
+3. Add ctypes bindings and GPU smoke tests that can skip when CUDA is missing.
+4. Extend `DeviceWeights`, `VelocityBuffers`, and checkpoint format for BN
+   affine and running-stat tensors.
+5. Extend `BatchWorkspace` and `cuda_batch.py` for Conv-BN-Activation call
+   order.
+6. Extend `cuda_legacy` config validation to accept only the exact BN placement
+   that the runtime supports.
+
+## Risk
+
+BatchNorm2d is a medium-high risk CUDA legacy change. It touches model
+validation, native kernels, workspace allocation, update semantics, checkpoint
+compatibility, and numerical parity. It should not be mixed into the same patch
+as unrelated optimizer or benchmark changes.
+

--- a/docs/dual_backend_guide.md
+++ b/docs/dual_backend_guide.md
@@ -124,6 +124,12 @@ Native CUDA backward files by operation:
 | Softmax / cross-entropy backward | `cpp/src/loss_layer.cu` | `src/minicnn/training/cuda_batch.py` |
 | LayerNorm backward | `cpp/src/layer_norm.cu` | Add a Python call site only if LayerNorm becomes part of CUDA legacy training. |
 
+`cpp/src/layer_norm.cu` is currently a tested native kernel asset, not a
+supported `cuda_legacy` training layer. `tests/test_layer_norm.py` mirrors the
+kernel math in NumPy and checks it against PyTorch. Wiring it into training
+would still require config validation, ctypes bindings, workspace buffers, and
+call-site integration.
+
 Rule of thumb:
 
 - If the change can be expressed with current `model.layers` or

--- a/docs/dual_backend_guide.md
+++ b/docs/dual_backend_guide.md
@@ -113,6 +113,12 @@ the requested layer behavior is outside the supported backend contract.
 
 Malformed CUDA legacy config values are collected as validation errors before the legacy experiment is compiled. If validation fails, fix the YAML or CLI override first rather than editing native code.
 
+CUDA legacy supports optional global gradient norm clipping through
+`optimizer.grad_clip_global`. The default `0.0` disables it. When enabled, the
+legacy batch step computes FC and Conv gradients first, derives one global scale,
+then applies the existing CUDA update kernels with adjusted gradient
+normalizers.
+
 Native CUDA backward files by operation:
 
 | Operation | Native file | Python call site |
@@ -123,6 +129,11 @@ Native CUDA backward files by operation:
 | LeakyReLU backward | `cpp/src/leaky_relu.cu` | `src/minicnn/training/cuda_batch.py` |
 | Softmax / cross-entropy backward | `cpp/src/loss_layer.cu` | `src/minicnn/training/cuda_batch.py` |
 | LayerNorm backward | `cpp/src/layer_norm.cu` | Add a Python call site only if LayerNorm becomes part of CUDA legacy training. |
+
+BatchNorm2d is evaluated separately in
+`docs/cuda_batchnorm2d_evaluation.md`. It is not only a kernel task: supported
+training needs BN affine parameters, running stats, workspace buffers,
+checkpointing, update semantics, validation, and parity tests.
 
 `cpp/src/layer_norm.cu` is currently a tested native kernel asset, not a
 supported `cuda_legacy` training layer. `tests/test_layer_norm.py` mirrors the

--- a/docs/optimization_progress.md
+++ b/docs/optimization_progress.md
@@ -1,0 +1,106 @@
+# MiniCNN Optimization Progress
+
+Last updated: 2026-04-20
+
+This file records the current optimization state for the MiniCNN follow-up work
+after comparing the project with `llm.c`, `tiny-cuda-nn`, and
+`neural-network-cuda`.
+
+## Current PR
+
+| Field | Value |
+|---|---|
+| PR | `https://github.com/s9213712/minicnn/pull/1` |
+| Branch | `codex/comparison-completion-report` |
+| Latest uploaded commit | `66082d3 Add CUDA legacy global grad clipping` |
+| CI status | GitHub Actions passed on Python 3.10, 3.11, and 3.12 |
+
+## Completed
+
+| Area | Status |
+|---|---|
+| Comparison report | Added backend-scoped completion report and linked it from README |
+| Follow-up tracking | Added `docs/comparison_followup_todo.md` |
+| Backend support matrix | Added `docs/backend_capabilities.md` |
+| Benchmark reporting | Added `docs/benchmark_report_template.md` |
+| `minicnn compare` UX | Added benchmark-ready fields and fixed `--backends ... key=value` parsing |
+| MNIST ctypes examples | Moved train scripts from `docs/` to `examples/mnist_ctypes/` |
+| Autograd losses | Added CPU/NumPy `MSELoss` and `BCEWithLogitsLoss` |
+| Autograd train config | `train-autograd` can select CrossEntropy, MSE, or BCEWithLogits |
+| PyTorch parity tests | Added parity tests for Linear, BatchNorm2d, MSE, and BCEWithLogits |
+| `Tensor.__pow__` warnings | Removed zero-base negative-exponent RuntimeWarnings |
+| CUDA legacy global grad clipping | Added `optimizer.grad_clip_global`, default disabled with `0.0` |
+| CUDA legacy BatchNorm2d | Evaluated scope and documented integration requirements |
+
+## CUDA Legacy Global Grad Clipping
+
+Implemented as a low-risk CUDA legacy optimizer improvement.
+
+- Config key: `optimizer.grad_clip_global`
+- Default: `0.0`, disabled
+- Validation accepts numeric values through unified config overrides
+- The CUDA batch step now computes FC and Conv gradients before applying
+  updates, derives one global norm scale, then applies the existing CUDA update
+  kernels through adjusted gradient normalizers
+- No native ABI was added for this step
+
+Example:
+
+```bash
+minicnn train-dual --config configs/dual_backend_cnn.yaml \
+  engine.backend=cuda_legacy optimizer.grad_clip_global=2.0
+```
+
+## CUDA Legacy BatchNorm2d Status
+
+BatchNorm2d is not blocked by theory, but it is not a one-kernel change. The
+current CUDA legacy training graph has no BN state, BN workspace, BN checkpoint
+fields, or Conv-BN-Activation call path.
+
+Current status:
+
+- Torch/flex backend: supported
+- CPU/NumPy autograd backend: supported
+- CUDA legacy backend: not supported yet
+
+Current user-facing behavior:
+
+```text
+cuda_legacy does not yet support BatchNorm2d in the training graph; use engine.backend=torch or remove BatchNorm2d for cuda_legacy
+```
+
+The implementation plan is recorded in
+`docs/cuda_batchnorm2d_evaluation.md`.
+
+## Validation
+
+Latest local validation before upload:
+
+```text
+PYTHONPATH=/home/s92137/NN/minicnn/src python3 -m pytest -q /home/s92137/NN/minicnn/tests
+117 passed
+
+python3 -m compileall -q /home/s92137/NN/minicnn/src /home/s92137/NN/minicnn/examples/mnist_ctypes
+passed
+
+git -C /home/s92137/NN/minicnn diff --check
+passed
+```
+
+Latest GitHub Actions validation for commit `66082d3`:
+
+```text
+test (3.10): success
+test (3.11): success
+test (3.12): success
+```
+
+## Remaining Work
+
+| Priority | Item | Notes |
+|---:|---|---|
+| 1 | CUDA Adam or AdamW | Needs optimizer state and update kernels |
+| 2 | CUDA BatchNorm2d | Needs kernels, runtime state, workspace, checkpoints, validation, and parity tests |
+| 3 | CUDA residual/skip add | Needs compiler/runtime representation first |
+| 4 | CUDA FP16/AMP | Deferred until baseline CUDA path is stronger |
+| 5 | Multi-GPU / NCCL / distributed | Deferred |

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This folder contains small extension examples for the configuration-driven path.
 
 - `custom_block.py`: custom activation and custom block classes usable from YAML via dotted import paths.
+- `mnist_ctypes/`: self-contained MNIST ctypes examples for the handcrafted CUDA shared library.
 
 Most training examples should start from `templates/` rather than editing Python
 directly. The legacy CUDA and Torch baseline trainers share common loop helpers

--- a/examples/mnist_ctypes/train_mnist_so.py
+++ b/examples/mnist_ctypes/train_mnist_so.py
@@ -29,7 +29,7 @@ from ctypes import c_float, c_int, c_void_p
 import numpy as np
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LIB = ROOT / "cpp" / "libminimal_cuda_cnn_handmade.so"
 DEFAULT_DATA = ROOT / "data" / "mnist"
 MNIST_URL = "https://storage.googleapis.com/cvdf-datasets/mnist"

--- a/examples/mnist_ctypes/train_mnist_so_full.py
+++ b/examples/mnist_ctypes/train_mnist_so_full.py
@@ -31,7 +31,7 @@ from ctypes import c_float, c_int, c_void_p
 import numpy as np
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LIB = ROOT / "cpp" / "libminimal_cuda_cnn_handmade.so"
 DEFAULT_DATA = ROOT / "data" / "mnist"
 DEFAULT_RUNS = ROOT / "runs" / "mnist_so"

--- a/examples/mnist_ctypes/train_mnist_so_full_cnn.py
+++ b/examples/mnist_ctypes/train_mnist_so_full_cnn.py
@@ -27,7 +27,7 @@ from ctypes import c_float, c_int, c_void_p
 import numpy as np
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LIB = ROOT / "cpp" / "libminimal_cuda_cnn_handmade.so"
 DEFAULT_DATA = ROOT / "data" / "mnist"
 DEFAULT_RUNS = ROOT / "runs" / "mnist_so_2conv"

--- a/examples/mnist_ctypes/train_mnist_so_full_cnn_frame.py
+++ b/examples/mnist_ctypes/train_mnist_so_full_cnn_frame.py
@@ -33,7 +33,7 @@ from ctypes import c_float, c_int, c_void_p
 import numpy as np
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LIB = ROOT / "cpp" / "libminimal_cuda_cnn_handmade.so"
 DEFAULT_DATA = ROOT / "data" / "mnist"
 DEFAULT_RUNS = ROOT / "runs" / "mnist_so_refactor"

--- a/src/minicnn/cli.py
+++ b/src/minicnn/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import time
 from pathlib import Path
+from typing import Any
 
 from minicnn.core.build import build_native, check_native
 from minicnn.flex.config import load_flex_config, dump_template
@@ -14,6 +15,9 @@ from minicnn.paths import CPP_ROOT, DATA_ROOT, PROJECT_ROOT
 from minicnn.unified.config import load_unified_config, dump_unified_template
 from minicnn.unified.cuda_legacy import CUDA_LEGACY_SUPPORTED, summarize_legacy_mapping, validate_cuda_legacy_compatibility
 from minicnn.unified.trainer import train_unified_from_config
+
+
+_COMPARE_BACKENDS = {'torch', 'cuda_legacy', 'autograd'}
 
 
 def _load_flex_config_or_exit(config_path: str, overrides: list[str]) -> dict:
@@ -89,6 +93,89 @@ def _common_train_overrides(args) -> list[str]:
     return overrides
 
 
+def _read_metrics(run_dir: Path) -> list[dict[str, Any]]:
+    metrics_path = run_dir / 'metrics.jsonl'
+    if not metrics_path.exists():
+        return []
+    rows = []
+    for line in metrics_path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def _effective_train_samples(cfg: dict[str, Any]) -> int:
+    dataset_cfg = cfg.get('dataset', {})
+    train_cfg = cfg.get('train', {})
+    num_samples = int(dataset_cfg.get('num_samples', 0) or 0)
+    batch_size = int(train_cfg.get('batch_size', 0) or 0)
+    max_steps = train_cfg.get('max_steps_per_epoch')
+    if max_steps is not None and batch_size > 0:
+        capped = int(max_steps) * batch_size
+        return min(num_samples, capped) if num_samples > 0 else capped
+    return num_samples
+
+
+def _round_or_none(value: float | None, digits: int = 3) -> float | None:
+    return round(value, digits) if value is not None else None
+
+
+def _benchmark_fields(backend: str, cfg: dict[str, Any], run_dir: Path, elapsed_s: float) -> dict[str, Any]:
+    train_cfg = cfg.get('train', {})
+    dataset_cfg = cfg.get('dataset', {})
+    runtime_cfg = cfg.get('runtime', {})
+    metrics = _read_metrics(run_dir)
+    epoch_times = [
+        float(row['epoch_time_s'])
+        for row in metrics
+        if row.get('epoch_time_s') is not None
+    ]
+    avg_epoch_time = sum(epoch_times) / len(epoch_times) if epoch_times else None
+    train_samples = _effective_train_samples(cfg)
+    throughput_window = avg_epoch_time if avg_epoch_time and avg_epoch_time > 0 else elapsed_s
+    samples_per_sec = (
+        train_samples / throughput_window
+        if train_samples > 0 and throughput_window > 0
+        else None
+    )
+    if backend == 'cuda_legacy':
+        variant = runtime_cfg.get('cuda_variant')
+    elif backend == 'torch':
+        variant = train_cfg.get('device')
+    else:
+        variant = ''
+    return {
+        'variant': variant or '',
+        'train_samples': train_samples,
+        'val_samples': int(dataset_cfg.get('val_samples', 0) or 0),
+        'batch_size': int(train_cfg.get('batch_size', 0) or 0),
+        'epochs_requested': int(train_cfg.get('epochs', 0) or 0),
+        'epochs_completed': len(metrics) if metrics else None,
+        'avg_epoch_time_s': _round_or_none(avg_epoch_time, digits=6),
+        'last_epoch_time_s': _round_or_none(epoch_times[-1] if epoch_times else None, digits=6),
+        'samples_per_sec': _round_or_none(samples_per_sec),
+        'elapsed_s': round(elapsed_s, 3),
+    }
+
+
+def _compare_backends_and_overrides(args) -> tuple[list[str], list[str]]:
+    if args.backends:
+        backends = []
+        extra_overrides = []
+        for token in args.backends:
+            if token in _COMPARE_BACKENDS and not extra_overrides:
+                backends.append(token)
+            elif '=' in token:
+                extra_overrides.append(token)
+            else:
+                expected = ', '.join(sorted(_COMPARE_BACKENDS))
+                raise ValueError(f"invalid compare backend {token!r}; expected one of: {expected}")
+        return backends, [*extra_overrides, *args.overrides]
+    backends = [b for b in (args.backend_a, args.backend_b) if b] or ['torch', 'cuda_legacy']
+    return backends, args.overrides
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog='minicnn', description='MiniCNN dual-backend CLI (pure handcrafted CUDA + PyTorch)')
     sub = parser.add_subparsers(dest='command', required=True)
@@ -147,7 +234,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_compare = sub.add_parser('compare', help='Run backend comparison with one shared config')
     p_compare.add_argument('--config', type=str, default='configs/dual_backend_cnn.yaml')
-    p_compare.add_argument('--backends', nargs='+', default=None, choices=['torch', 'cuda_legacy', 'autograd'])
+    p_compare.add_argument('--backends', nargs='+', default=None, metavar='BACKEND')
     p_compare.add_argument('--backend-a', choices=['torch', 'cuda_legacy', 'autograd'])
     p_compare.add_argument('--backend-b', choices=['torch', 'cuda_legacy', 'autograd'])
     _add_common_train_args(p_compare)
@@ -276,26 +363,30 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == 'compare':
         rows = []
-        backends = args.backends or [b for b in (args.backend_a, args.backend_b) if b] or ['torch', 'cuda_legacy']
+        try:
+            backends, compare_overrides = _compare_backends_and_overrides(args)
+        except ValueError as exc:
+            parser.error(str(exc))
         for backend in backends:
             t0 = time.perf_counter()
             if backend == 'autograd':
                 from minicnn.training.train_autograd import train_autograd_from_config
-                cfg = load_flex_config(args.config if args.config else None, [*_common_train_overrides(args), *args.overrides])
+                cfg = load_flex_config(args.config if args.config else None, [*_common_train_overrides(args), *compare_overrides])
                 run_dir = train_autograd_from_config(cfg)
             else:
-                cfg = _load_unified_config_or_exit(args.config, [f'engine.backend={backend}', *_common_train_overrides(args), *args.overrides])
+                cfg = _load_unified_config_or_exit(args.config, [f'engine.backend={backend}', *_common_train_overrides(args), *compare_overrides])
                 run_dir = train_unified_from_config(cfg)
             elapsed = time.perf_counter() - t0
             summary_path = run_dir / 'summary.json'
             summary = json.loads(summary_path.read_text(encoding='utf-8')) if summary_path.exists() else {}
-            rows.append({
+            row = {
                 'backend': backend,
                 'run_dir': str(run_dir),
                 'best_model_path': summary.get('best_model_path'),
                 'test_acc': summary.get('test_acc'),
-                'elapsed_s': round(elapsed, 3),
-            })
+            }
+            row.update(_benchmark_fields(backend, cfg, run_dir, elapsed))
+            rows.append(row)
         print(json.dumps({'runs': rows}, indent=2))
         return 0
 

--- a/src/minicnn/config/schema.py
+++ b/src/minicnn/config/schema.py
@@ -51,6 +51,7 @@ class OptimConfig:
     grad_clip_fc: float = 1.0
     grad_clip_bias: float = 5.0
     grad_pool_clip: float = 1.0
+    grad_clip_global: float = 0.0
     conv_grad_spatial_normalize: bool = False
 
 

--- a/src/minicnn/config/settings.py
+++ b/src/minicnn/config/settings.py
@@ -40,6 +40,7 @@ _ENV_OVERRIDES = {
     "LR_FC": ("MINICNN_LR_FC", float),
     "MOMENTUM": ("MINICNN_MOMENTUM", float),
     "WEIGHT_DECAY": ("MINICNN_WEIGHT_DECAY", float),
+    "GRAD_CLIP_GLOBAL": ("MINICNN_GRAD_CLIP_GLOBAL", float),
 }
 
 
@@ -92,6 +93,7 @@ def apply_experiment_config(cfg: ExperimentConfig) -> None:
         "GRAD_CLIP_FC": cfg.optim.grad_clip_fc,
         "GRAD_CLIP_BIAS": cfg.optim.grad_clip_bias,
         "GRAD_POOL_CLIP": cfg.optim.grad_pool_clip,
+        "GRAD_CLIP_GLOBAL": cfg.optim.grad_clip_global,
         "CONV_GRAD_SPATIAL_NORMALIZE": cfg.optim.conv_grad_spatial_normalize,
         "GRAD_DEBUG": cfg.runtime.grad_debug,
         "GRAD_DEBUG_BATCHES": cfg.runtime.grad_debug_batches,
@@ -147,6 +149,7 @@ def summarize() -> dict[str, Any]:
             "lr_fc": LR_FC,
             "momentum": MOMENTUM,
             "weight_decay": WEIGHT_DECAY,
+            "grad_clip_global": GRAD_CLIP_GLOBAL,
         },
         "model": {
             "stages": [

--- a/src/minicnn/flex/builder.py
+++ b/src/minicnn/flex/builder.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover
     nn = None
 
 
-CUDA_LEGACY_OPTIMIZER_KEYS = {'lr_conv1', 'lr_conv', 'lr_fc'}
+CUDA_LEGACY_OPTIMIZER_KEYS = {'lr_conv1', 'lr_conv', 'lr_fc', 'grad_clip_global'}
 _PASSTHROUGH_LAYERS = {
     'BatchNorm2d',
     'Dropout',

--- a/src/minicnn/nn/__init__.py
+++ b/src/minicnn/nn/__init__.py
@@ -1,6 +1,17 @@
 from minicnn.nn.modules import Module, Sequential
 from minicnn.nn.layers import BatchNorm2d, Conv2d, Dropout, Flatten, Linear, MaxPool2d, ReLU, ResidualBlock, Sigmoid, Tanh
-from minicnn.nn.tensor import Parameter, Tensor, cross_entropy, log_softmax, no_grad, relu, sigmoid, tanh
+from minicnn.nn.tensor import (
+    Parameter,
+    Tensor,
+    bce_with_logits_loss,
+    cross_entropy,
+    log_softmax,
+    mse_loss,
+    no_grad,
+    relu,
+    sigmoid,
+    tanh,
+)
 
 __all__ = [
     'BatchNorm2d',
@@ -17,8 +28,10 @@ __all__ = [
     'Sigmoid',
     'Tanh',
     'Tensor',
+    'bce_with_logits_loss',
     'cross_entropy',
     'log_softmax',
+    'mse_loss',
     'no_grad',
     'relu',
     'sigmoid',

--- a/src/minicnn/nn/tensor.py
+++ b/src/minicnn/nn/tensor.py
@@ -377,3 +377,43 @@ def cross_entropy(logits: Tensor, targets: Any) -> Tensor:
 
     out._backward = _backward
     return out
+
+
+def mse_loss(predictions: Tensor, targets: Any) -> Tensor:
+    targets = targets if isinstance(targets, Tensor) else Tensor(targets)
+    if predictions.data.shape != targets.data.shape:
+        raise ValueError(
+            f'mse_loss target shape {targets.data.shape} does not match predictions shape {predictions.data.shape}'
+        )
+    return ((predictions - targets) ** 2).mean()
+
+
+def bce_with_logits_loss(logits: Tensor, targets: Any) -> Tensor:
+    targets = targets if isinstance(targets, Tensor) else Tensor(targets)
+    if logits.data.shape != targets.data.shape:
+        raise ValueError(
+            f'bce_with_logits_loss target shape {targets.data.shape} does not match logits shape {logits.data.shape}'
+        )
+
+    logits_data = logits.data.astype(np.float32)
+    target_data = targets.data.astype(np.float32)
+    loss_terms = np.maximum(logits_data, 0.0) - logits_data * target_data + np.log1p(np.exp(-np.abs(logits_data)))
+    loss_val = loss_terms.mean()
+    out = Tensor(loss_val, requires_grad=_requires_grad(logits, targets))
+    out._prev = {logits, targets}
+    out._op = 'bce_with_logits_loss'
+
+    def _backward() -> None:
+        if out.grad is None:
+            return
+        scale = np.asarray(out.grad, dtype=np.float32) / float(logits_data.size)
+        sigmoid_vals = np.empty_like(logits_data, dtype=np.float32)
+        pos = logits_data >= 0.0
+        sigmoid_vals[pos] = 1.0 / (1.0 + np.exp(-logits_data[pos]))
+        exp_vals = np.exp(logits_data[~pos])
+        sigmoid_vals[~pos] = exp_vals / (1.0 + exp_vals)
+        logits._add_grad((sigmoid_vals - target_data) * scale)
+        targets._add_grad((-logits_data) * scale)
+
+    out._backward = _backward
+    return out

--- a/src/minicnn/nn/tensor.py
+++ b/src/minicnn/nn/tensor.py
@@ -175,7 +175,9 @@ class Tensor:
         return other * (self ** -1.0)
 
     def __pow__(self, power: float) -> 'Tensor':
-        out = Tensor(self.data ** power, requires_grad=_requires_grad(self))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            data = self.data ** power
+        out = Tensor(data, requires_grad=_requires_grad(self))
         out._prev = {self}
         out._op = 'pow'
 
@@ -183,9 +185,13 @@ class Tensor:
             if out.grad is not None:
                 if power < 1.0:
                     # Avoid NaN at zero: treat gradient as 0 where base is 0.
-                    base_grad = np.where(self.data != 0.0, power * (self.data ** (power - 1.0)), 0.0)
+                    base_grad = np.zeros_like(self.data, dtype=np.float32)
+                    mask = self.data != 0.0
+                    with np.errstate(divide='ignore', invalid='ignore'):
+                        base_grad[mask] = power * (self.data[mask] ** (power - 1.0))
                 else:
-                    base_grad = power * (self.data ** (power - 1.0))
+                    with np.errstate(divide='ignore', invalid='ignore'):
+                        base_grad = power * (self.data ** (power - 1.0))
                 self._add_grad(out.grad * base_grad)
 
         out._backward = _backward

--- a/src/minicnn/training/cuda_batch.py
+++ b/src/minicnn/training/cuda_batch.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from ctypes import c_float
 from dataclasses import dataclass
+import math
 
 import numpy as np
 
 from minicnn.core.cuda_backend import (
     download_float_scalar,
     download_int_scalar,
+    g2h,
     lib,
     update_conv,
 )
@@ -17,6 +19,7 @@ from minicnn.config.settings import (
     GRAD_CLIP_BIAS,
     GRAD_CLIP_CONV,
     GRAD_CLIP_FC,
+    GRAD_CLIP_GLOBAL,
     GRAD_POOL_CLIP,
     LEAKY_ALPHA,
     MOMENTUM,
@@ -44,13 +47,42 @@ _C_GRAD_CLIP_BIAS = c_float(GRAD_CLIP_BIAS)
 _C_GRAD_POOL_CLIP = c_float(GRAD_POOL_CLIP)
 _C_LEAKY_ALPHA   = c_float(LEAKY_ALPHA)
 _C_ZERO          = c_float(0.0)
-_C_ONE           = c_float(1.0)
 
 
 @dataclass
 class CudaRuntimeState:
     weights: DeviceWeights
     velocities: VelocityBuffers
+
+
+def global_clip_scale(total_grad_sq: float, max_norm: float, eps: float = 1e-12) -> float:
+    """Return the gradient scale for global-norm clipping.
+
+    A non-positive max_norm disables global clipping. The returned value is in
+    (0, 1], so existing CUDA update kernels can apply it by increasing their
+    gradient normalizer.
+    """
+    if max_norm <= 0.0:
+        return 1.0
+    norm = math.sqrt(max(float(total_grad_sq), 0.0))
+    if norm <= max_norm:
+        return 1.0
+    return float(max_norm / (norm + eps))
+
+
+def scaled_normalizer(base_normalizer: float, scale: float) -> float:
+    if scale <= 0.0:
+        return float('inf')
+    return float(base_normalizer) / float(scale)
+
+
+def device_grad_sq(d_grad, size: int, normalizer: float = 1.0) -> float:
+    if size <= 0:
+        return 0.0
+    grad = g2h(d_grad, size).astype(np.float64, copy=False).reshape(-1)
+    if normalizer != 1.0:
+        grad = grad / float(normalizer)
+    return float(np.dot(grad, grad))
 
 
 def synchronize_if_available() -> None:
@@ -167,13 +199,12 @@ def compute_loss_and_metrics(
     )
 
 
-def backward_fc_update(
+def backward_fc(
     runtime: CudaRuntimeState,
     workspace: BatchWorkspace,
     arch: CudaNetGeometry,
     fc_input,
     batch_size: int,
-    lr_state: LrState,
 ) -> None:
     lib.dense_backward_full(
         workspace.d_grad_logits,
@@ -186,6 +217,16 @@ def backward_fc_update(
         arch.fc_in,
         arch.fc_out,
     )
+
+
+def update_fc(
+    runtime: CudaRuntimeState,
+    workspace: BatchWorkspace,
+    arch: CudaNetGeometry,
+    lr_state: LrState,
+    grad_scale: float = 1.0,
+) -> None:
+    normalizer = c_float(scaled_normalizer(1.0, grad_scale))
     lib.conv_update_fused(
         runtime.weights.fc_w,
         workspace.d_fc_grad_w,
@@ -194,7 +235,7 @@ def backward_fc_update(
         _C_MOMENTUM,
         _C_WEIGHT_DECAY,
         _C_GRAD_CLIP_FC,
-        _C_ONE,
+        normalizer,
         arch.fc_out * arch.fc_in,
     )
     lib.conv_update_fused(
@@ -205,18 +246,23 @@ def backward_fc_update(
         _C_MOMENTUM,
         _C_ZERO,
         _C_GRAD_CLIP_BIAS,
-        _C_ONE,
+        normalizer,
         arch.fc_out,
     )
 
 
-def backward_convs_update(
+def conv_grad_normalizers(arch: CudaNetGeometry) -> list[float]:
+    normalizers = []
+    for stage in arch.conv_stages:
+        normalizers.append(float(stage.h_out * stage.w_out if CONV_GRAD_SPATIAL_NORMALIZE else 1.0))
+    return normalizers
+
+
+def backward_convs(
     runtime: CudaRuntimeState,
     workspace: BatchWorkspace,
     arch: CudaNetGeometry,
     batch_size: int,
-    lr_state: LrState,
-    log_grad: bool,
 ) -> None:
     lib.clip_inplace(workspace.d_pre_fc_grad_nchw, _C_GRAD_POOL_CLIP, batch_size * arch.fc_in)
     grad_nchw = workspace.d_pre_fc_grad_nchw
@@ -277,8 +323,32 @@ def backward_convs_update(
             stage.out_c,
         )
 
+        grad_nchw = workspace.d_input_nchw_grad[i]
+
+
+def cuda_global_grad_scale(workspace: BatchWorkspace, arch: CudaNetGeometry, max_norm: float) -> float:
+    if max_norm <= 0.0:
+        return 1.0
+    total_sq = device_grad_sq(workspace.d_fc_grad_w, arch.fc_out * arch.fc_in)
+    total_sq += device_grad_sq(workspace.d_fc_grad_b, arch.fc_out)
+    normalizers = conv_grad_normalizers(arch)
+    for i, stage in enumerate(arch.conv_stages):
+        total_sq += device_grad_sq(workspace.d_w_grad[i], stage.weight_numel, normalizers[i])
+    return global_clip_scale(total_sq, max_norm)
+
+
+def update_convs(
+    runtime: CudaRuntimeState,
+    workspace: BatchWorkspace,
+    arch: CudaNetGeometry,
+    lr_state: LrState,
+    grad_scale: float,
+    log_grad: bool,
+) -> None:
+    normalizers = conv_grad_normalizers(arch)
+    for i, stage in enumerate(arch.conv_stages):
         lr = lr_state.conv1 if i == 0 else lr_state.conv
-        spatial_norm = stage.h_out * stage.w_out if CONV_GRAD_SPATIAL_NORMALIZE else 1.0
+        spatial_norm = scaled_normalizer(normalizers[i], grad_scale)
         update_conv(
             runtime.weights.conv_weights[i],
             workspace.d_w_grad[i],
@@ -292,8 +362,6 @@ def backward_convs_update(
             spatial_norm,
             log_grad,
         )
-
-        grad_nchw = workspace.d_input_nchw_grad[i]
 
 
 def train_cuda_batch(
@@ -311,5 +379,8 @@ def train_cuda_batch(
     fc_input = forward_convs(runtime, workspace, arch, batch_size)
     forward_fc(runtime, workspace, arch, fc_input, batch_size)
     compute_loss_and_metrics(workspace, arch, metrics, batch_size)
-    backward_fc_update(runtime, workspace, arch, fc_input, batch_size, lr_state)
-    backward_convs_update(runtime, workspace, arch, batch_size, lr_state, log_grad)
+    backward_fc(runtime, workspace, arch, fc_input, batch_size)
+    backward_convs(runtime, workspace, arch, batch_size)
+    grad_scale = cuda_global_grad_scale(workspace, arch, GRAD_CLIP_GLOBAL)
+    update_fc(runtime, workspace, arch, lr_state, grad_scale)
+    update_convs(runtime, workspace, arch, lr_state, grad_scale, log_grad)

--- a/src/minicnn/training/train_autograd.py
+++ b/src/minicnn/training/train_autograd.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from minicnn.flex.runtime import create_run_dir, dump_summary
 from minicnn.models import build_model_from_config
-from minicnn.nn import Tensor, cross_entropy, no_grad
+from minicnn.nn import Tensor, bce_with_logits_loss, cross_entropy, mse_loss, no_grad
 from minicnn.optim import Adam, SGD
 from minicnn.paths import BEST_MODELS_ROOT, DATA_ROOT
 
@@ -98,6 +98,32 @@ def _make_optimizer(params, cfg: dict[str, Any]):
     return SGD(params, lr=lr, momentum=float(cfg.get('momentum', 0.0)), weight_decay=weight_decay, grad_clip=grad_clip)
 
 
+def _dense_targets(labels: np.ndarray, logits_shape: tuple[int, ...], loss_type: str) -> np.ndarray:
+    if len(logits_shape) != 2:
+        raise ValueError(f'{loss_type} expects 2D logits in train-autograd, got shape {logits_shape}')
+    batch, outputs = logits_shape
+    if labels.shape[0] != batch:
+        raise ValueError(f'target batch size {labels.shape[0]} does not match logits batch size {batch}')
+    if outputs == 1:
+        return labels.reshape(batch, 1).astype(np.float32)
+    dense = np.zeros((batch, outputs), dtype=np.float32)
+    dense[np.arange(batch), labels.astype(np.int64)] = 1.0
+    return dense
+
+
+def _make_loss(loss_cfg: dict[str, Any]):
+    loss_type = str(loss_cfg.get('type', 'CrossEntropyLoss'))
+    if loss_type == 'CrossEntropyLoss':
+        return lambda logits, labels: cross_entropy(logits, labels)
+    if loss_type == 'MSELoss':
+        return lambda logits, labels: mse_loss(logits, _dense_targets(labels, logits.data.shape, loss_type))
+    if loss_type == 'BCEWithLogitsLoss':
+        return lambda logits, labels: bce_with_logits_loss(logits, _dense_targets(labels, logits.data.shape, loss_type))
+    raise ValueError(
+        "train-autograd supports loss.type values: CrossEntropyLoss, MSELoss, BCEWithLogitsLoss"
+    )
+
+
 def _accuracy(model, x, y, batch_size: int) -> float:
     correct = 0
     total = 0
@@ -128,6 +154,7 @@ def train_autograd_from_config(cfg: dict[str, Any]) -> Path:
     )
     optim_cfg = cfg.get('optimizer', {'type': 'SGD', 'lr': 0.01})
     optimizer = _make_optimizer(model.parameters(), optim_cfg)
+    loss_fn = _make_loss(cfg.get('loss', {'type': 'CrossEntropyLoss'}))
     batch_size = int(train_cfg.get('batch_size', 8))
     epochs = int(train_cfg.get('epochs', 1))
 
@@ -158,7 +185,7 @@ def train_autograd_from_config(cfg: dict[str, Any]) -> Path:
                 yb = y_train[idx]
                 optimizer.zero_grad()
                 logits = model(xb)
-                loss = cross_entropy(logits, yb)
+                loss = loss_fn(logits, yb)
                 loss.backward()
                 optimizer.step()
                 total_loss += float(loss.data) * len(idx)

--- a/src/minicnn/unified/cuda_legacy.py
+++ b/src/minicnn/unified/cuda_legacy.py
@@ -62,6 +62,11 @@ def _collect_conv_blocks(model_cfg: dict[str, Any]) -> tuple[list[dict[str, Any]
     expected = CUDA_LEGACY_SUPPORTED['layer_pattern']
     for layer in layers:
         name = _normalize_layer_name(layer)
+        if name == 'BatchNorm2d':
+            raise ValueError(
+                'cuda_legacy does not yet support BatchNorm2d in the training graph; '
+                'use engine.backend=torch or remove BatchNorm2d for cuda_legacy'
+            )
         if expected_idx >= len(expected):
             raise ValueError('Too many layers for cuda_legacy backend')
         allowed = expected[expected_idx]
@@ -130,6 +135,7 @@ def validate_cuda_legacy_compatibility(cfg: dict[str, Any]) -> list[str]:
         ('optimizer.lr_fc', optim.get('lr_fc', optim.get('lr', 0.0))),
         ('optimizer.momentum', optim.get('momentum', 0.0)),
         ('optimizer.weight_decay', optim.get('weight_decay', 0.0)),
+        ('optimizer.grad_clip_global', optim.get('grad_clip_global', 0.0)),
     ):
         _coerce_float(value, label, errors)
     cuda_variant = runtime.get('cuda_variant')
@@ -227,6 +233,7 @@ def compile_to_legacy_experiment(cfg: dict[str, Any]) -> ExperimentConfig:
     exp.optim.lr_fc = float(optim.get('lr_fc', optim.get('lr', exp.optim.lr_fc)))
     exp.optim.momentum = float(optim.get('momentum', exp.optim.momentum))
     exp.optim.weight_decay = float(optim.get('weight_decay', exp.optim.weight_decay))
+    exp.optim.grad_clip_global = float(optim.get('grad_clip_global', exp.optim.grad_clip_global))
     exp.optim.leaky_alpha = negative_slope
 
     input_shape = dataset.get('input_shape', [3, 32, 32])
@@ -260,6 +267,7 @@ def summarize_legacy_mapping(cfg: dict[str, Any]) -> dict[str, Any]:
             'lr_fc': data['optim']['lr_fc'],
             'momentum': data['optim']['momentum'],
             'weight_decay': data['optim']['weight_decay'],
+            'grad_clip_global': data['optim']['grad_clip_global'],
             'leaky_alpha': data['optim']['leaky_alpha'],
         },
         'train': {

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from minicnn.nn import Parameter, Tensor, cross_entropy
+from minicnn.nn import Parameter, Tensor, bce_with_logits_loss, cross_entropy, mse_loss
 from minicnn.optim.sgd import SGD
 
 
@@ -52,6 +52,47 @@ def test_cross_entropy_backward_matches_softmax_gradient():
 
     assert loss.data.shape == ()
     assert np.allclose(logits.grad, expected, atol=1e-6)
+
+
+def test_mse_loss_backward_matches_mean_squared_error_gradient():
+    predictions = Tensor([[1.0, -2.0], [0.5, 3.0]], requires_grad=True)
+    targets = np.array([[0.0, -1.0], [1.5, 1.0]], dtype=np.float32)
+
+    loss = mse_loss(predictions, targets)
+    loss.backward()
+
+    expected_loss = np.mean((predictions.data - targets) ** 2)
+    expected_grad = 2.0 * (predictions.data - targets) / predictions.data.size
+
+    assert np.allclose(loss.data, expected_loss)
+    assert np.allclose(predictions.grad, expected_grad)
+
+
+def test_bce_with_logits_loss_backward_matches_sigmoid_gradient():
+    logits = Tensor([[0.0, 2.0], [-1.0, 4.0]], requires_grad=True)
+    targets = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+
+    loss = bce_with_logits_loss(logits, targets)
+    loss.backward()
+
+    expected_loss = np.mean(np.maximum(logits.data, 0.0) - logits.data * targets + np.log1p(np.exp(-np.abs(logits.data))))
+    sigmoid_vals = 1.0 / (1.0 + np.exp(-logits.data))
+    expected_grad = (sigmoid_vals - targets) / logits.data.size
+
+    assert np.allclose(loss.data, expected_loss)
+    assert np.allclose(logits.grad, expected_grad)
+
+
+def test_bce_with_logits_loss_handles_large_logits_without_overflow():
+    logits = Tensor([[1000.0, -1000.0]], requires_grad=True)
+    targets = np.array([[1.0, 0.0]], dtype=np.float32)
+
+    with np.errstate(over='raise', invalid='raise'):
+        loss = bce_with_logits_loss(logits, targets)
+        loss.backward()
+
+    assert np.isfinite(loss.data)
+    assert np.allclose(logits.grad, [[0.0, 0.0]], atol=1e-6)
 
 
 def test_parameter_and_sgd_step_without_torch():

--- a/tests/test_autograd_parity.py
+++ b/tests/test_autograd_parity.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pytest
+
+from minicnn.nn import BatchNorm2d, Linear, Tensor, bce_with_logits_loss, mse_loss
+
+
+torch = pytest.importorskip("torch")
+
+
+def test_linear_forward_backward_matches_torch():
+    rng = np.random.default_rng(123)
+    x_np = rng.standard_normal((3, 4)).astype(np.float32)
+    w_np = rng.standard_normal((4, 2)).astype(np.float32)
+    b_np = rng.standard_normal(2).astype(np.float32)
+
+    layer = Linear(4, 2)
+    layer.weight.data[...] = w_np
+    layer.bias.data[...] = b_np
+    x = Tensor(x_np, requires_grad=True)
+    y = layer(x)
+    y.sum().backward()
+
+    x_ref = torch.tensor(x_np, requires_grad=True)
+    w_ref = torch.tensor(w_np.T, requires_grad=True)
+    b_ref = torch.tensor(b_np, requires_grad=True)
+    y_ref = torch.nn.functional.linear(x_ref, w_ref, b_ref)
+    y_ref.sum().backward()
+
+    np.testing.assert_allclose(y.data, y_ref.detach().numpy(), atol=1e-6)
+    np.testing.assert_allclose(x.grad, x_ref.grad.numpy(), atol=1e-6)
+    np.testing.assert_allclose(layer.weight.grad, w_ref.grad.numpy().T, atol=1e-6)
+    np.testing.assert_allclose(layer.bias.grad, b_ref.grad.numpy(), atol=1e-6)
+
+
+def test_mse_loss_backward_matches_torch():
+    predictions_np = np.array([[0.5, -1.0], [2.0, 3.0]], dtype=np.float32)
+    targets_np = np.array([[1.5, 0.0], [1.0, 2.5]], dtype=np.float32)
+
+    predictions = Tensor(predictions_np, requires_grad=True)
+    loss = mse_loss(predictions, targets_np)
+    loss.backward()
+
+    predictions_ref = torch.tensor(predictions_np, requires_grad=True)
+    targets_ref = torch.tensor(targets_np)
+    loss_ref = torch.nn.functional.mse_loss(predictions_ref, targets_ref)
+    loss_ref.backward()
+
+    np.testing.assert_allclose(loss.data, loss_ref.detach().numpy(), atol=1e-6)
+    np.testing.assert_allclose(predictions.grad, predictions_ref.grad.numpy(), atol=1e-6)
+
+
+def test_bce_with_logits_loss_backward_matches_torch():
+    logits_np = np.array([[0.0, 2.0], [-1.0, 4.0]], dtype=np.float32)
+    targets_np = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+
+    logits = Tensor(logits_np, requires_grad=True)
+    loss = bce_with_logits_loss(logits, targets_np)
+    loss.backward()
+
+    logits_ref = torch.tensor(logits_np, requires_grad=True)
+    targets_ref = torch.tensor(targets_np)
+    loss_ref = torch.nn.functional.binary_cross_entropy_with_logits(logits_ref, targets_ref)
+    loss_ref.backward()
+
+    np.testing.assert_allclose(loss.data, loss_ref.detach().numpy(), atol=1e-6)
+    np.testing.assert_allclose(logits.grad, logits_ref.grad.numpy(), atol=1e-6)
+
+
+def test_batchnorm2d_forward_backward_matches_torch_train_mode():
+    rng = np.random.default_rng(456)
+    x_np = rng.standard_normal((2, 3, 4, 4)).astype(np.float32)
+    gamma_np = rng.standard_normal(3).astype(np.float32)
+    beta_np = rng.standard_normal(3).astype(np.float32)
+
+    bn = BatchNorm2d(3, eps=1e-5, momentum=0.1)
+    bn.weight.data[...] = gamma_np
+    bn.bias.data[...] = beta_np
+    x = Tensor(x_np, requires_grad=True)
+    y = bn(x)
+    y.sum().backward()
+
+    bn_ref = torch.nn.BatchNorm2d(3, eps=1e-5, momentum=0.1, affine=True, track_running_stats=True)
+    with torch.no_grad():
+        bn_ref.weight.copy_(torch.tensor(gamma_np))
+        bn_ref.bias.copy_(torch.tensor(beta_np))
+        bn_ref.running_mean.zero_()
+        bn_ref.running_var.fill_(1.0)
+    bn_ref.train()
+    x_ref = torch.tensor(x_np, requires_grad=True)
+    y_ref = bn_ref(x_ref)
+    y_ref.sum().backward()
+
+    np.testing.assert_allclose(y.data, y_ref.detach().numpy(), atol=1e-5)
+    np.testing.assert_allclose(x.grad, x_ref.grad.numpy(), atol=1e-5)
+    np.testing.assert_allclose(bn.weight.grad, bn_ref.weight.grad.numpy(), atol=1e-5)
+    np.testing.assert_allclose(bn.bias.grad, bn_ref.bias.grad.numpy(), atol=1e-5)

--- a/tests/test_comment_fixes.py
+++ b/tests/test_comment_fixes.py
@@ -126,6 +126,55 @@ def test_cli_seed_overrides_keep_dataset_init_and_train_seeds_separate():
     assert 'dataset.seed=222' not in overrides
 
 
+def test_cli_benchmark_fields_read_metrics_for_compare(tmp_path):
+    from minicnn.cli import _benchmark_fields
+
+    (tmp_path / 'metrics.jsonl').write_text(
+        '{"epoch": 1, "epoch_time_s": 1.0}\n'
+        '{"epoch": 2, "epoch_time_s": 2.0}\n',
+        encoding='utf-8',
+    )
+    cfg = {
+        'runtime': {'cuda_variant': 'cublas'},
+        'dataset': {'num_samples': 128, 'val_samples': 32},
+        'train': {'batch_size': 32, 'epochs': 2, 'max_steps_per_epoch': 2},
+    }
+
+    fields = _benchmark_fields('cuda_legacy', cfg, tmp_path, elapsed_s=10.0)
+
+    assert fields['variant'] == 'cublas'
+    assert fields['train_samples'] == 64
+    assert fields['val_samples'] == 32
+    assert fields['batch_size'] == 32
+    assert fields['epochs_requested'] == 2
+    assert fields['epochs_completed'] == 2
+    assert fields['avg_epoch_time_s'] == 1.5
+    assert fields['last_epoch_time_s'] == 2.0
+    assert fields['samples_per_sec'] == 42.667
+
+    torch_fields = _benchmark_fields('torch', cfg | {'train': {'device': 'cpu'}}, tmp_path, elapsed_s=10.0)
+    assert torch_fields['variant'] == 'cpu'
+
+    autograd_fields = _benchmark_fields('autograd', cfg | {'train': {'device': 'auto'}}, tmp_path, elapsed_s=10.0)
+    assert autograd_fields['variant'] == ''
+
+
+def test_cli_compare_backends_allow_key_value_overrides_after_backends():
+    from minicnn.cli import _compare_backends_and_overrides, build_parser
+
+    args = build_parser().parse_args([
+        'compare',
+        '--backends', 'torch', 'cuda_legacy',
+        'train.epochs=1',
+        'dataset.num_samples=8',
+    ])
+
+    backends, overrides = _compare_backends_and_overrides(args)
+
+    assert backends == ['torch', 'cuda_legacy']
+    assert overrides == ['train.epochs=1', 'dataset.num_samples=8']
+
+
 def test_build_native_passes_cuda_arch_to_make_and_cmake(monkeypatch):
     from minicnn.core import build
 

--- a/tests/test_cuda_global_clip.py
+++ b/tests/test_cuda_global_clip.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+import minicnn.training.cuda_batch as cuda_batch
+
+
+def test_global_clip_scale_disabled_or_under_limit():
+    assert cuda_batch.global_clip_scale(total_grad_sq=100.0, max_norm=0.0) == 1.0
+    assert cuda_batch.global_clip_scale(total_grad_sq=4.0, max_norm=2.0) == 1.0
+    assert cuda_batch.global_clip_scale(total_grad_sq=1.0, max_norm=-1.0) == 1.0
+
+
+def test_global_clip_scale_scales_down_by_norm():
+    scale = cuda_batch.global_clip_scale(total_grad_sq=25.0, max_norm=2.0)
+    assert math.isclose(scale, 0.4, rel_tol=1e-9)
+
+
+def test_scaled_normalizer_applies_clip_scale_through_existing_update_api():
+    assert cuda_batch.scaled_normalizer(8.0, 1.0) == 8.0
+    assert cuda_batch.scaled_normalizer(8.0, 0.25) == 32.0
+
+
+def test_device_grad_sq_uses_normalized_gradient(monkeypatch):
+    monkeypatch.setattr(cuda_batch, 'g2h', lambda _ptr, _size: np.array([2.0, 4.0], dtype=np.float32))
+
+    assert cuda_batch.device_grad_sq(object(), 2, normalizer=2.0) == 5.0
+

--- a/tests/test_flex_training.py
+++ b/tests/test_flex_training.py
@@ -87,6 +87,7 @@ def test_optimizer_ignores_cuda_legacy_lr_fields_for_torch():
         'lr_conv1': 0.02,
         'lr_conv': 0.03,
         'lr_fc': 0.04,
+        'grad_clip_global': 1.0,
         'momentum': 0.0,
     }
     param = torch.nn.Parameter(torch.zeros(1))

--- a/tests/test_mnist_templates.py
+++ b/tests/test_mnist_templates.py
@@ -101,7 +101,7 @@ def test_repository_templates_materialize_supported_torch_models():
 
 
 def test_refactored_mnist_so_example_keeps_optimizer_separate_from_layers():
-    source = (Path(__file__).resolve().parents[1] / 'docs' / 'train_mnist_so_full_cnn_frame.py').read_text()
+    source = (Path(__file__).resolve().parents[1] / 'examples' / 'mnist_ctypes' / 'train_mnist_so_full_cnn_frame.py').read_text()
 
     assert 'class ConvBlock' in source
     assert 'class DenseLayer' in source

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -81,9 +81,12 @@ def test_sgd_momentum_two_steps_matches_expected_velocity():
 
 def test_pow_negative_exponent_zero_base_no_nan_grad():
     x = Tensor(np.array([0.0, 1.0, 2.0], dtype=np.float32), requires_grad=True)
-    y = (x ** -1.0).sum()
-    y.backward()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        y = (x ** -1.0).sum()
+        y.backward()
 
+    assert not caught
     assert not np.any(np.isnan(x.grad)), \
         "Gradient should not contain NaN for 0**-1"
     assert np.allclose(x.grad[1:], [-1.0, -0.25], atol=1e-6)
@@ -91,8 +94,12 @@ def test_pow_negative_exponent_zero_base_no_nan_grad():
 
 def test_pow_negative_exponent_zero_base_grad_is_zero():
     x = Tensor(np.array([0.0], dtype=np.float32), requires_grad=True)
-    y = (x ** -2.0).sum()
-    y.backward()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        y = (x ** -2.0).sum()
+        y.backward()
+
+    assert not caught
     assert x.grad[0] == 0.0
 
 

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -96,7 +96,8 @@ def test_legacy_trainers_are_split_into_backend_steps():
 
     assert 'def train_cuda_batch' in cuda_batch
     assert 'def forward_convs' in cuda_batch
-    assert 'def backward_convs_update' in cuda_batch
+    assert 'def backward_convs' in cuda_batch
+    assert 'def update_convs' in cuda_batch
     assert '_d_weights' not in train_cuda
     assert 'train_cuda_batch(' in train_cuda
 

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -70,6 +70,18 @@ def test_compile_cuda_legacy_maps_distinct_dataset_init_and_train_seeds():
     assert exp.train.train_seed == 333
 
 
+def test_compile_cuda_legacy_maps_global_grad_clip():
+    cfg = load_unified_config(Path(__file__).resolve().parents[1] / 'configs' / 'dual_backend_cnn.yaml', [
+        'engine.backend=cuda_legacy',
+        'optimizer.grad_clip_global=2.5',
+    ])
+
+    assert validate_cuda_legacy_compatibility(cfg) == []
+    exp = compile_to_legacy_experiment(cfg)
+
+    assert exp.optim.grad_clip_global == 2.5
+
+
 def test_cuda_legacy_accepts_native_variant_runtime_option():
     cfg = load_unified_config(None, ['engine.backend=cuda_legacy', 'runtime.cuda_variant=handmade'])
     errors = validate_cuda_legacy_compatibility(cfg)

--- a/tests/test_unified_validation.py
+++ b/tests/test_unified_validation.py
@@ -17,6 +17,24 @@ def test_cuda_legacy_rejects_unsupported_layer_sequence():
     assert any('expects exactly' in err or 'expects layer' in err for err in errors)
 
 
+def test_cuda_legacy_rejects_batchnorm2d_with_actionable_message():
+    cfg = {
+        'dataset': {'type': 'cifar10', 'input_shape': [3, 32, 32], 'num_classes': 10},
+        'model': {'layers': [
+            {'type': 'Conv2d', 'out_channels': 32, 'kernel_size': 3, 'stride': 1, 'padding': 0},
+            {'type': 'BatchNorm2d'},
+            {'type': 'LeakyReLU', 'negative_slope': 0.1},
+        ]},
+        'train': {'amp': False, 'grad_accum_steps': 1},
+        'loss': {'type': 'CrossEntropyLoss'},
+        'optimizer': {'type': 'SGD', 'lr': 0.01},
+    }
+
+    errors = validate_cuda_legacy_compatibility(cfg)
+
+    assert any('does not yet support BatchNorm2d' in err for err in errors)
+
+
 def test_cuda_legacy_rejects_unknown_native_variant():
     cfg = {
         'runtime': {'cuda_variant': 'experimental'},


### PR DESCRIPTION
## Summary

- Adds the MiniCNN comparison completion report, follow-up TODO log, backend capability matrix, benchmark report template, and current optimization progress snapshot.
- Adds autograd `MSELoss` and `BCEWithLogitsLoss` support plus `train-autograd` target conversion for dense loss targets.
- Adds PyTorch parity coverage for Linear, BatchNorm2d, MSE, and BCEWithLogits.
- Moves MNIST ctypes training scripts out of `docs/` into `examples/mnist_ctypes/` and updates references.
- Extends `minicnn compare` with benchmark-ready fields: train/val samples, batch size, completed epochs, average/last epoch time, samples/sec, and elapsed time.
- Fixes `minicnn compare --backends ... key=value` parsing so backend lists and config overrides work in one command.
- Cleans up `Tensor.__pow__` zero-base negative-exponent RuntimeWarnings while preserving zero-gradient behavior.
- Adds CUDA legacy global gradient norm clipping via `optimizer.grad_clip_global`.
- Records CUDA legacy BatchNorm2d forward/backward integration requirements and adds a clearer validation error for unsupported BatchNorm2d configs.

## Why

The comparison against `karpathy/llm.c`, `NVlabs/tiny-cuda-nn`, and `BobMcDear/neural-network-cuda` identified documentation gaps, unclear backend capability boundaries, missing non-CE loss options, tutorial code living under `docs/`, and a need for repeatable benchmark reporting. This PR records the plan and implements low-risk items that improve usability, validation, and test coverage now.

## Validation

- `PYTHONPATH=/home/s92137/NN/minicnn/src python3 -m pytest -q /home/s92137/NN/minicnn/tests` -> 117 passed before the docs-only progress snapshot commit.
- `python3 -m compileall -q /home/s92137/NN/minicnn/src /home/s92137/NN/minicnn/examples/mnist_ctypes` passed before the docs-only progress snapshot commit.
- `git -C /home/s92137/NN/minicnn diff --check` passed for the progress snapshot commit.
- Smoke: `PYTHONPATH=/home/s92137/NN/minicnn/src python3 -m minicnn.cli compare --config /home/s92137/NN/minicnn/configs/autograd_tiny.yaml --backends autograd train.epochs=1 dataset.num_samples=8 dataset.val_samples=4 dataset.test_samples=4 project.artifacts_root=/tmp/minicnn_compare_bench_smoke`.
- Smoke: `PYTHONPATH=/home/s92137/NN/minicnn/src python3 -m minicnn.cli validate-dual-config --config /home/s92137/NN/minicnn/configs/dual_backend_cnn.yaml engine.backend=cuda_legacy optimizer.grad_clip_global=2.0`.
- Smoke: `PYTHONPATH=/home/s92137/NN/minicnn/src python3 -m minicnn.cli validate-dual-config --config /home/s92137/NN/minicnn/configs/dual_backend_cnn.yaml engine.backend=cuda_legacy model.layers.1.type=BatchNorm2d` returns the expected unsupported-BatchNorm2d validation error.

## Notes

This remains a draft PR. CUDA BatchNorm2d is documented as evaluated but not implemented in the handcrafted training graph yet; it needs native kernels, state, workspace, checkpointing, update semantics, validation, and parity tests before it should be marked supported.